### PR TITLE
chore(package): Upgrade to go 1.20

### DIFF
--- a/extended/go.mod
+++ b/extended/go.mod
@@ -1,12 +1,17 @@
 module example.com/extended
 
-go 1.16
+go 1.20
 
 require (
 	github.com/aws/constructs-go/constructs/v10 v10.1.52
 	github.com/aws/jsii-runtime-go v1.63.2
 	github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2 v2.3.61
 	github.com/coopnorge/cdk8slibrary v0.0.1-alpha4
+)
+
+require (
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/creasty/defaults v1.6.0 // indirect
 )
 
 //replace github.com/coopnorge/cdk8slibrary v0.0.1-alpha5 => ../../cdk8slibrary

--- a/simple/go.mod
+++ b/simple/go.mod
@@ -1,6 +1,6 @@
 module example.com/simple
 
-go 1.18
+go 1.20
 
 require (
 	github.com/aws/constructs-go/constructs/v10 v10.1.65


### PR DESCRIPTION
Updates go to version 1.20 and runs `go mod tidy`.

Before:
  `go 1.19`

Before:
  `go 1.17`

After:
  `go 1.20`